### PR TITLE
execution.cpp: use Linux-specific signals conditionally

### DIFF
--- a/src/core/execution.cpp
+++ b/src/core/execution.cpp
@@ -134,11 +134,22 @@ std::string message(int sig, bool core_dumped) {
         {SIGHUP, cyan}, {SIGINT, yellow}, {SIGQUIT, red}, {SIGILL, red},
         {SIGTRAP, red}, {SIGABRT, red}, {SIGBUS, red}, {SIGFPE, red},
         {SIGKILL, red}, {SIGUSR1, yellow}, {SIGSEGV, red}, {SIGUSR2, yellow},
-        {SIGPIPE, cyan}, {SIGALRM, cyan}, {SIGTERM, yellow}, {SIGSTKFLT, red},
+        {SIGPIPE, cyan}, {SIGALRM, cyan}, {SIGTERM, yellow},
+    #ifdef SIGSTKFLT
+        {SIGSTKFLT, red},
+    #endif
         {SIGCHLD, cyan}, {SIGCONT, cyan}, {SIGSTOP, red}, {SIGTSTP, yellow},
         {SIGTTIN, cyan}, {SIGTTOU, cyan}, {SIGURG, cyan}, {SIGXCPU, red},
         {SIGXFSZ, red}, {SIGVTALRM, cyan}, {SIGPROF, cyan}, {SIGWINCH, cyan},
-        {SIGPOLL, cyan}, {SIGPWR, red}, {SIGSYS, red}
+    #ifdef SIGPOLL
+        {SIGPOLL, cyan},
+    #endif
+    #ifdef SIGPWR
+        {SIGPWR, red},
+    #endif
+    #ifdef SIGSYS
+        {SIGSYS, red}
+    #endif
     };
 
     const char* sig_name = strsignal(sig); // human-readable signal name


### PR DESCRIPTION
Fix the failure on macOS:
```
/opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/core/execution.cpp:137:63: error: 'SIGSTKFLT' was not declared in this scope; did you mean 'SIGSTKSZ'?
  137 |         {SIGPIPE, cyan}, {SIGALRM, cyan}, {SIGTERM, yellow}, {SIGSTKFLT, red},
      |                                                               ^~~~~~~~~
      |                                                               SIGSTKSZ
/opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/core/execution.cpp:141:10: error: 'SIGPOLL' was not declared in this scope; did you mean 'SIGKILL'?
  141 |         {SIGPOLL, cyan}, {SIGPWR, red}, {SIGSYS, red}
      |          ^~~~~~~
      |          SIGKILL
/opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/core/execution.cpp:141:27: error: 'SIGPWR' was not declared in this scope
  141 |         {SIGPOLL, cyan}, {SIGPWR, red}, {SIGSYS, red}
      |                           ^~~~~~
/opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/core/execution.cpp:142:5: error: could not convert '{{1, cyan}, {2, yellow}, {3, red}, {4, red}, {5, red}, {6, red}, {10, red}, {8, red}, {9, red}, {30, yellow}, {11, red}, {31, yellow}, {13, cyan}, {14, cyan}, {15, yellow}, {<expression error>, red}, {20, cyan}, {19, cyan}, {17, red}, {18, yellow}, {21, cyan}, {22, cyan}, {16, cyan}, {24, red}, {25, red}, {26, cyan}, {27, cyan}, {28, cyan}, {<expression error>, cyan}, {<expression error>, red}, {12, red}}' from '<brace-enclosed initializer list>' to 'std::map<int, std::basic_string<char> >'
  142 |     };
      |     ^
      |     |
      |     <brace-enclosed initializer list>
[ 57%] Building CXX object CMakeFiles/slash.dir/src/abstractions/info.cpp.o
/opt/local/bin/g++-mp-14 -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -isystem /opt/local/libexec/boost/1.81/include -pipe -I/opt/local/libexec/boost/1.81/include -Os -DNDEBUG -I/opt/local/libexec/boost/1.81/include -I/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -g -std=gnu++20 -arch ppc64 -mmacosx-version-min=10.5 -MD -MT CMakeFiles/slash.dir/src/abstractions/info.cpp.o -MF CMakeFiles/slash.dir/src/abstractions/info.cpp.o.d -o CMakeFiles/slash.dir/src/abstractions/info.cpp.o -c /opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/abstractions/info.cpp
make[2]: *** [CMakeFiles/slash.dir/src/core/execution.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/core/prompt.cpp: In function 'SegmentStyle get_segment_style(std::string, bool, bool)':
/opt/local/var/macports/build/slash-5cd7486e/work/slash-934576c4e280ee5af570b07d1e611478f23bab22/src/core/prompt.cpp:104:1: warning: control reaches end of non-void function [-Wreturn-type]
  104 | }
      | ^
make[2]: Leaving directory `/opt/local/var/macports/build/slash-5cd7486e/work/build'
make[1]: *** [CMakeFiles/slash.dir/all] Error 2
```